### PR TITLE
v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ GyverHX711 sensor(data, clock, gain);
 ## Использование
 ```cpp
 bool available();           // true - доступен для чтения
-long read();                // получить данные
+long read();                // получить данные с фильтрацией
+long read_current_value();  // получить данные без фильтрации
 void tare();                // тарировать (автоматическая калибровка)
 void setOffset(long cal);   // установить оффсет вручную
 long getOffset();           // получить оффсет
@@ -61,10 +62,10 @@ GyverHX711 sensor(7, 8, HX_GAIN128_A);
 
 void setup() {
   Serial.begin(9600);
-  sensor.tare();		// калибровка нуля
+  sensor.tare();              // калибровка нуля
   
-  //sensor.sleepMode(true);		// выключить датчик
-  //sensor.sleepMode(false);	// включить датчик
+  //sensor.sleepMode(true);   // выключить датчик
+  //sensor.sleepMode(false);  // включить датчик
 }
 
 void loop() {

--- a/examples/test/test.ino
+++ b/examples/test/test.ino
@@ -1,8 +1,8 @@
 #include <GyverHX711.h>
 GyverHX711 sensor(7, 8, HX_GAIN128_A);
-// HX_A_GAIN128 - канал А усиление 128
-// HX_B_GAIN32 - канал B усиление 32
-// HX_A_GAIN64 - канал А усиление 64
+// HX_GAIN128_A - канал А усиление 128
+// HX_GAIN32_B - канал B усиление 32
+// HX_GAIN64_A - канал А усиление 64
 
 void setup() {
   Serial.begin(9600);


### PR DESCRIPTION
- поддержка отрицательных значений.  
  Я использовал [вот такой датчик](https://www.zemiceurope.com/media/Documentation/L6D_Datasheet.pdf) на 5 кг. Без этой правки фигня со значениями выходит если его отклонить в другую сторону.
- возможность получить значение без фильтрации.  
  Мне надо получать данные как есть, я думаю я не один такой буду. Может быть есть смысл сделать это параметром при инициализации датчика, но все же я реализовал просто отдельный метод.
- возможно тарировать до получения первого значения.  
  В первой реализации надо сделать три измерения до тарирования что бы медианный фильтр адекватно заработал. Я сделал что бы оно просто сделало новое значение если измерений еще не было. Может быть есть смысл сделать что бы при тарировании оно делало три измерения и прогнало их через фильтр.
- Вроде как обратная совместимость сохраняется, ничего не должно поломаться что уже использует эту библиотеку.

П.С. Алекс, я обычно стараюсь маркдаун писать максимально по гайдлайну, я могу переделывать редмихи что бы они соответствовали гайдлайнам, или ты предпочитаешь работать с тем как ты их пишешь?